### PR TITLE
Split blacklist keys into groups

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -10,8 +10,10 @@ Conditionally roll out features with redis.
 
 Initialize a feature_flags object. I assign it to a global var.
 
+  # Usage: FeatureFlags.new(redis, namespace, group_size)
+
   $redis   = Redis.new
-  $feature_flags = FeatureFlags.new($redis)
+  $feature_flags = FeatureFlags.new($redis, 'namespace', 100_000)
 
 == City Flags ==
 

--- a/lib/feature_flags.rb
+++ b/lib/feature_flags.rb
@@ -1,5 +1,5 @@
 class FeatureFlags
-  def initialize(redis, namespace, group_size)
+  def initialize(redis, namespace, group_size = 100_000)
     @redis = redis
     @namespace = namespace
     @group_size = group_size

--- a/lib/feature_flags.rb
+++ b/lib/feature_flags.rb
@@ -42,7 +42,7 @@ class FeatureFlags
 
   def activate_user(feature:, city_id:, id:)
     if city_live?(feature: feature, city_id: city_id)
-      @redis.srem(blacklist_user_key(feature), id)
+      @redis.srem(blacklist_user_key(feature, id), id)
     elsif city_beta?(feature: feature, city_id: city_id)
       @redis.sadd(whitelist_user_key(feature), id)
     end
@@ -50,7 +50,7 @@ class FeatureFlags
 
   def deactivate_user(feature:, city_id:, id:)
     if city_live?(feature: feature, city_id: city_id)
-      @redis.sadd(blacklist_user_key(feature), id)
+      @redis.sadd(blacklist_user_key(feature, id), id)
     elsif city_beta?(feature: feature, city_id: city_id)
       @redis.srem(whitelist_user_key(feature), id)
     end
@@ -60,7 +60,7 @@ class FeatureFlags
     return false if feature.nil? || city_id.nil? || id.nil?
 
     if city_live?(feature: feature, city_id: city_id)
-      !@redis.sismember(blacklist_user_key(feature), id)
+      !@redis.sismember(blacklist_user_key(feature, id), id)
     elsif city_beta?(feature: feature, city_id: city_id)
       @redis.sismember(whitelist_user_key(feature), id)
     else
@@ -100,8 +100,8 @@ class FeatureFlags
     "city_#{feature}_beta"
   end
 
-  def blacklist_user_key(feature)
-    "user_#{feature}_blacklist"
+  def blacklist_user_key(feature, id)
+    "user_#{feature}_blacklist_#{id / 1000}"
   end
 
   def whitelist_user_key(feature)

--- a/lib/feature_flags.rb
+++ b/lib/feature_flags.rb
@@ -101,7 +101,7 @@ class FeatureFlags
   end
 
   def blacklist_user_key(feature, id)
-    "user_#{feature}_blacklist_#{id / 1000}"
+    "user_#{feature}_blacklist_#{id / 100_000}"
   end
 
   def whitelist_user_key(feature)

--- a/lib/feature_flags.rb
+++ b/lib/feature_flags.rb
@@ -1,6 +1,8 @@
 class FeatureFlags
-  def initialize(redis)
-    @redis  = redis
+  def initialize(redis, namespace, group_size)
+    @redis = redis
+    @namespace = namespace
+    @group_size = group_size
   end
 
   # cashless_live: [1, 2, 3] # cashless_beta: [4, 5, 6]
@@ -93,18 +95,18 @@ class FeatureFlags
   end
 
   def live_features_key(feature)
-    "city_#{feature}_live"
+    "#{@namespace}_city_#{feature}_live"
   end
 
   def beta_features_key(feature)
-    "city_#{feature}_beta"
+    "#{@namespace}_city_#{feature}_beta"
   end
 
   def blacklist_user_key(feature, id)
-    "user_#{feature}_blacklist_#{id / 100_000}"
+    "#{@namespace}_user_#{feature}_blacklist_#{id / @group_size}"
   end
 
   def whitelist_user_key(feature)
-    "user_#{feature}_whitelist"
+    "#{@namespace}_user_#{feature}_whitelist"
   end
 end

--- a/spec/feature_flags_spec.rb
+++ b/spec/feature_flags_spec.rb
@@ -3,41 +3,41 @@ require 'spec_helper'
 describe "FeatureFlags" do
   before do
     @redis   = Redis.new
-    @feature_flags = FeatureFlags.new(@redis)
+    @feature_flags = FeatureFlags.new(@redis, 'test', 100_000)
   end
 
   describe '#activate_city' do
     it 'adds the city id to the live features set if live is passed as true' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: true)
-      expect(@redis.sismember('city_cashless_live', 1)).to be true
-      expect(@redis.sismember('city_cashless_beta', 1)).to be false
+      expect(@redis.sismember('test_city_cashless_live', 1)).to be true
+      expect(@redis.sismember('test_city_cashless_beta', 1)).to be false
     end
 
     it 'adds the city id to the beta features set if live is passed as false' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: false)
-      expect(@redis.sismember('city_cashless_beta', 1)).to be true
-      expect(@redis.sismember('city_cashless_live', 1)).to be false
+      expect(@redis.sismember('test_city_cashless_beta', 1)).to be true
+      expect(@redis.sismember('test_city_cashless_live', 1)).to be false
     end
 
     it 'if nil city id is passed in it does not do anything' do
       @feature_flags.activate_city(feature: :cashless, city_id: nil, live: false)
-      expect(@redis.sismember('city_cashless_beta', 1)).to be false
-      expect(@redis.sismember('city_cashless_live', 1)).to be false
+      expect(@redis.sismember('test_city_cashless_beta', 1)).to be false
+      expect(@redis.sismember('test_city_cashless_live', 1)).to be false
     end
 
     it 'if nil feature is passed in it does not do anything' do
       @feature_flags.activate_city(feature: nil, city_id: 1, live: false)
-      expect(@redis.sismember('city_cashless_beta', 1)).to be false
-      expect(@redis.sismember('city_cashless_live', 1)).to be false
+      expect(@redis.sismember('test_city_cashless_beta', 1)).to be false
+      expect(@redis.sismember('test_city_cashless_live', 1)).to be false
     end
   end
 
   describe '#deactivate_city' do
-    before { @redis.sadd('city_cashless_live', 1) }
+    before { @redis.sadd('test_city_cashless_live', 1) }
 
     it 'removes the city from both the live set and the beta set' do
       @feature_flags.deactivate_city(feature: :cashless, city_id: 1)
-      expect(@redis.sismember('city_cashless_live', 1)).to be false
+      expect(@redis.sismember('test_city_cashless_live', 1)).to be false
     end
   end
 
@@ -65,33 +65,33 @@ describe "FeatureFlags" do
     it 'does not add the user to any list if the feature is non-existent' do
       @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 1)
 
-      expect(@redis.sismember('user_cashless_blacklist_0', 1)).to be false
-      expect(@redis.sismember('user_cashless_whitelist', 1)).to be false
+      expect(@redis.sismember('test_user_cashless_blacklist_0', 1)).to be false
+      expect(@redis.sismember('test_user_cashless_whitelist', 1)).to be false
     end
 
     it 'does not add the user to any list if the feature is live for the city' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: true)
       @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 123_456)
 
-      expect(@redis.sismember('user_cashless_blacklist_1', 123_456)).to be false
-      expect(@redis.sismember('user_cashless_whitelist', 123_456)).to be false
+      expect(@redis.sismember('test_user_cashless_blacklist_1', 123_456)).to be false
+      expect(@redis.sismember('test_user_cashless_whitelist', 123_456)).to be false
     end
 
     it 'adds the user to the whitelist if the feature is in beta for the city' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: false)
       @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 234_567)
 
-      expect(@redis.sismember('user_cashless_blacklist_2', 234_567)).to be false
-      expect(@redis.sismember('user_cashless_whitelist', 234_567)).to be true
+      expect(@redis.sismember('test_user_cashless_blacklist_2', 234_567)).to be false
+      expect(@redis.sismember('test_user_cashless_whitelist', 234_567)).to be true
     end
 
     it 'removes the user from the blacklist if the feature is live for the city' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: true)
       @feature_flags.deactivate_user(feature: :cashless, city_id: 1, id: 345_678)
-      expect(@redis.sismember('user_cashless_blacklist_3', 345_678)).to be true
+      expect(@redis.sismember('test_user_cashless_blacklist_3', 345_678)).to be true
 
       @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 345_678)
-      expect(@redis.sismember('user_cashless_blacklist_3', 345_678)).to be false
+      expect(@redis.sismember('test_user_cashless_blacklist_3', 345_678)).to be false
     end
   end
 
@@ -99,33 +99,33 @@ describe "FeatureFlags" do
     it 'does not add the user to any list if the feature is non-existent' do
       @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 456_789)
 
-      expect(@redis.sismember('user_cashless_blacklist_4', 456_789)).to be false
-      expect(@redis.sismember('user_cashless_whitelist', 456_789)).to be false
+      expect(@redis.sismember('test_user_cashless_blacklist_4', 456_789)).to be false
+      expect(@redis.sismember('test_user_cashless_whitelist', 456_789)).to be false
     end
 
     it 'adds the user to the blacklist if the feature is live for the city' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: true)
       @feature_flags.deactivate_user(feature: :cashless, city_id: 1, id: 567_890)
 
-      expect(@redis.sismember('user_cashless_blacklist_5', 567_890)).to be true
-      expect(@redis.sismember('user_cashless_whitelist', 567_890)).to be false
+      expect(@redis.sismember('test_user_cashless_blacklist_5', 567_890)).to be true
+      expect(@redis.sismember('test_user_cashless_whitelist', 567_890)).to be false
     end
 
     it 'does not add the user to any list if the feature is in beta for the city' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: false)
       @feature_flags.deactivate_user(feature: :cashless, city_id: 1, id: 678_901)
 
-      expect(@redis.sismember('user_cashless_blacklist_6', 678_901)).to be false
-      expect(@redis.sismember('user_cashless_whitelist', 678_901)).to be false
+      expect(@redis.sismember('test_user_cashless_blacklist_6', 678_901)).to be false
+      expect(@redis.sismember('test_user_cashless_whitelist', 678_901)).to be false
     end
 
     it 'removes the user from the whitelist if the feature is in beta for the city' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: false)
       @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 1)
-      expect(@redis.sismember('user_cashless_whitelist', 1)).to be true
+      expect(@redis.sismember('test_user_cashless_whitelist', 1)).to be true
 
       @feature_flags.deactivate_user(feature: :cashless, city_id: 1, id: 1)
-      expect(@redis.sismember('user_cashless_whitelist', 1)).to be false
+      expect(@redis.sismember('test_user_cashless_whitelist', 1)).to be false
     end
   end
 
@@ -148,28 +148,28 @@ describe "FeatureFlags" do
 
     it 'returns false when blacklisted for a feature which is live' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: true)
-      @redis.sadd('user_cashless_blacklist_7', 789_012)
+      @redis.sadd('test_user_cashless_blacklist_7', 789_012)
 
       expect(@feature_flags.user_active?(feature: :cashless, city_id: 1, id: 789_012)).to be false
     end
 
     it 'returns false when not whitelisted for a feature which is in beta' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: false)
-      @redis.srem('user_cashless_whitelist', 1)
+      @redis.srem('test_user_cashless_whitelist', 1)
 
       expect(@feature_flags.user_active?(feature: :cashless, city_id: 1, id: 1)).to be false
     end
 
     it 'returns true when whitelisted for a feature which is beta' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: false)
-      @redis.sadd('user_cashless_whitelist', 1)
+      @redis.sadd('test_user_cashless_whitelist', 1)
 
       expect(@feature_flags.user_active?(feature: :cashless, city_id: 1, id: 1)).to be true
     end
 
     it 'returns true when not blacklisted for a feature which is live' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: true)
-      @redis.srem('user_cashless_blacklist_8', 890_123)
+      @redis.srem('test_user_cashless_blacklist_8', 890_123)
 
       expect(@feature_flags.user_active?(feature: :cashless, city_id: 1, id: 890_123)).to be true
     end

--- a/spec/feature_flags_spec.rb
+++ b/spec/feature_flags_spec.rb
@@ -65,58 +65,58 @@ describe "FeatureFlags" do
     it 'does not add the user to any list if the feature is non-existent' do
       @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 1)
 
-      expect(@redis.sismember('user_cashless_blacklist', 1)).to be false
+      expect(@redis.sismember('user_cashless_blacklist_0', 1)).to be false
       expect(@redis.sismember('user_cashless_whitelist', 1)).to be false
     end
 
     it 'does not add the user to any list if the feature is live for the city' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: true)
-      @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 1)
+      @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 1234)
 
-      expect(@redis.sismember('user_cashless_blacklist', 1)).to be false
-      expect(@redis.sismember('user_cashless_whitelist', 1)).to be false
+      expect(@redis.sismember('user_cashless_blacklist_1', 1234)).to be false
+      expect(@redis.sismember('user_cashless_whitelist', 1234)).to be false
     end
 
     it 'adds the user to the whitelist if the feature is in beta for the city' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: false)
-      @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 1)
+      @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 2345)
 
-      expect(@redis.sismember('user_cashless_blacklist', 1)).to be false
-      expect(@redis.sismember('user_cashless_whitelist', 1)).to be true
+      expect(@redis.sismember('user_cashless_blacklist_2', 2345)).to be false
+      expect(@redis.sismember('user_cashless_whitelist', 2345)).to be true
     end
 
     it 'removes the user from the blacklist if the feature is live for the city' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: true)
-      @feature_flags.deactivate_user(feature: :cashless, city_id: 1, id: 1)
-      expect(@redis.sismember('user_cashless_blacklist', 1)).to be true
+      @feature_flags.deactivate_user(feature: :cashless, city_id: 1, id: 3456)
+      expect(@redis.sismember('user_cashless_blacklist_3', 3456)).to be true
 
-      @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 1)
-      expect(@redis.sismember('user_cashless_blacklist', 1)).to be false
+      @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 3456)
+      expect(@redis.sismember('user_cashless_blacklist_3', 3456)).to be false
     end
   end
 
   describe '#deactivate_user' do
     it 'does not add the user to any list if the feature is non-existent' do
-      @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 1)
+      @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 4567)
 
-      expect(@redis.sismember('user_cashless_blacklist', 1)).to be false
-      expect(@redis.sismember('user_cashless_whitelist', 1)).to be false
+      expect(@redis.sismember('user_cashless_blacklist_4', 4567)).to be false
+      expect(@redis.sismember('user_cashless_whitelist', 4567)).to be false
     end
 
     it 'adds the user to the blacklist if the feature is live for the city' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: true)
-      @feature_flags.deactivate_user(feature: :cashless, city_id: 1, id: 1)
+      @feature_flags.deactivate_user(feature: :cashless, city_id: 1, id: 5678)
 
-      expect(@redis.sismember('user_cashless_blacklist', 1)).to be true
-      expect(@redis.sismember('user_cashless_whitelist', 1)).to be false
+      expect(@redis.sismember('user_cashless_blacklist_5', 5678)).to be true
+      expect(@redis.sismember('user_cashless_whitelist', 5678)).to be false
     end
 
     it 'does not add the user to any list if the feature is in beta for the city' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: false)
-      @feature_flags.deactivate_user(feature: :cashless, city_id: 1, id: 1)
+      @feature_flags.deactivate_user(feature: :cashless, city_id: 1, id: 6789)
 
-      expect(@redis.sismember('user_cashless_blacklist', 1)).to be false
-      expect(@redis.sismember('user_cashless_whitelist', 1)).to be false
+      expect(@redis.sismember('user_cashless_blacklist_6', 6789)).to be false
+      expect(@redis.sismember('user_cashless_whitelist', 6789)).to be false
     end
 
     it 'removes the user from the whitelist if the feature is in beta for the city' do
@@ -148,9 +148,9 @@ describe "FeatureFlags" do
 
     it 'returns false when blacklisted for a feature which is live' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: true)
-      @redis.sadd('user_cashless_blacklist', 1)
+      @redis.sadd('user_cashless_blacklist_7', 7890)
 
-      expect(@feature_flags.user_active?(feature: :cashless, city_id: 1, id: 1)).to be false
+      expect(@feature_flags.user_active?(feature: :cashless, city_id: 1, id: 7890)).to be false
     end
 
     it 'returns false when not whitelisted for a feature which is in beta' do
@@ -169,9 +169,9 @@ describe "FeatureFlags" do
 
     it 'returns true when not blacklisted for a feature which is live' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: true)
-      @redis.srem('user_cashless_blacklist', 1)
+      @redis.srem('user_cashless_blacklist_8', 8901)
 
-      expect(@feature_flags.user_active?(feature: :cashless, city_id: 1, id: 1)).to be true
+      expect(@feature_flags.user_active?(feature: :cashless, city_id: 1, id: 8901)).to be true
     end
   end
 

--- a/spec/feature_flags_spec.rb
+++ b/spec/feature_flags_spec.rb
@@ -71,52 +71,52 @@ describe "FeatureFlags" do
 
     it 'does not add the user to any list if the feature is live for the city' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: true)
-      @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 1234)
+      @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 123_456)
 
-      expect(@redis.sismember('user_cashless_blacklist_1', 1234)).to be false
-      expect(@redis.sismember('user_cashless_whitelist', 1234)).to be false
+      expect(@redis.sismember('user_cashless_blacklist_1', 123_456)).to be false
+      expect(@redis.sismember('user_cashless_whitelist', 123_456)).to be false
     end
 
     it 'adds the user to the whitelist if the feature is in beta for the city' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: false)
-      @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 2345)
+      @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 234_567)
 
-      expect(@redis.sismember('user_cashless_blacklist_2', 2345)).to be false
-      expect(@redis.sismember('user_cashless_whitelist', 2345)).to be true
+      expect(@redis.sismember('user_cashless_blacklist_2', 234_567)).to be false
+      expect(@redis.sismember('user_cashless_whitelist', 234_567)).to be true
     end
 
     it 'removes the user from the blacklist if the feature is live for the city' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: true)
-      @feature_flags.deactivate_user(feature: :cashless, city_id: 1, id: 3456)
-      expect(@redis.sismember('user_cashless_blacklist_3', 3456)).to be true
+      @feature_flags.deactivate_user(feature: :cashless, city_id: 1, id: 345_678)
+      expect(@redis.sismember('user_cashless_blacklist_3', 345_678)).to be true
 
-      @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 3456)
-      expect(@redis.sismember('user_cashless_blacklist_3', 3456)).to be false
+      @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 345_678)
+      expect(@redis.sismember('user_cashless_blacklist_3', 345_678)).to be false
     end
   end
 
   describe '#deactivate_user' do
     it 'does not add the user to any list if the feature is non-existent' do
-      @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 4567)
+      @feature_flags.activate_user(feature: :cashless, city_id: 1, id: 456_789)
 
-      expect(@redis.sismember('user_cashless_blacklist_4', 4567)).to be false
-      expect(@redis.sismember('user_cashless_whitelist', 4567)).to be false
+      expect(@redis.sismember('user_cashless_blacklist_4', 456_789)).to be false
+      expect(@redis.sismember('user_cashless_whitelist', 456_789)).to be false
     end
 
     it 'adds the user to the blacklist if the feature is live for the city' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: true)
-      @feature_flags.deactivate_user(feature: :cashless, city_id: 1, id: 5678)
+      @feature_flags.deactivate_user(feature: :cashless, city_id: 1, id: 567_890)
 
-      expect(@redis.sismember('user_cashless_blacklist_5', 5678)).to be true
-      expect(@redis.sismember('user_cashless_whitelist', 5678)).to be false
+      expect(@redis.sismember('user_cashless_blacklist_5', 567_890)).to be true
+      expect(@redis.sismember('user_cashless_whitelist', 567_890)).to be false
     end
 
     it 'does not add the user to any list if the feature is in beta for the city' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: false)
-      @feature_flags.deactivate_user(feature: :cashless, city_id: 1, id: 6789)
+      @feature_flags.deactivate_user(feature: :cashless, city_id: 1, id: 678_901)
 
-      expect(@redis.sismember('user_cashless_blacklist_6', 6789)).to be false
-      expect(@redis.sismember('user_cashless_whitelist', 6789)).to be false
+      expect(@redis.sismember('user_cashless_blacklist_6', 678_901)).to be false
+      expect(@redis.sismember('user_cashless_whitelist', 678_901)).to be false
     end
 
     it 'removes the user from the whitelist if the feature is in beta for the city' do
@@ -148,9 +148,9 @@ describe "FeatureFlags" do
 
     it 'returns false when blacklisted for a feature which is live' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: true)
-      @redis.sadd('user_cashless_blacklist_7', 7890)
+      @redis.sadd('user_cashless_blacklist_7', 789_012)
 
-      expect(@feature_flags.user_active?(feature: :cashless, city_id: 1, id: 7890)).to be false
+      expect(@feature_flags.user_active?(feature: :cashless, city_id: 1, id: 789_012)).to be false
     end
 
     it 'returns false when not whitelisted for a feature which is in beta' do
@@ -169,9 +169,9 @@ describe "FeatureFlags" do
 
     it 'returns true when not blacklisted for a feature which is live' do
       @feature_flags.activate_city(feature: :cashless, city_id: 1, live: true)
-      @redis.srem('user_cashless_blacklist_8', 8901)
+      @redis.srem('user_cashless_blacklist_8', 890_123)
 
-      expect(@feature_flags.user_active?(feature: :cashless, city_id: 1, id: 8901)).to be true
+      expect(@feature_flags.user_active?(feature: :cashless, city_id: 1, id: 890_123)).to be true
     end
   end
 

--- a/spec/feature_flags_spec.rb
+++ b/spec/feature_flags_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "FeatureFlags" do
   before do
     @redis   = Redis.new
-    @feature_flags = FeatureFlags.new(@redis, 'test', 100_000)
+    @feature_flags = FeatureFlags.new(@redis, 'test') # Default group_size 100_000
   end
 
   describe '#activate_city' do


### PR DESCRIPTION
- Add namespace support.
- Pass `group_size` as an initialization argument.
- Split blacklist into groups.
