### PR TITLE
Set user flags regardless of cities

### DIFF
--- a/lib/feature_flags.rb
+++ b/lib/feature_flags.rb
@@ -60,6 +60,7 @@ class FeatureFlags
       @redis.srem(whitelist_user_key(feature), id)
     else
       @redis.sadd(whitelist_user_key(feature), id)
+      @redis.srem(blacklist_user_key(feature, id), id)
     end
   end
 

--- a/spec/feature_flags_spec.rb
+++ b/spec/feature_flags_spec.rb
@@ -96,18 +96,27 @@ describe "FeatureFlags" do
     end
 
     it 'adds the user to the whitelist if setting the feature as beta for the user' do
-      @feature_flags.activate_user(feature: :cashless, id: 234_567, live: false)
+      @feature_flags.deactivate_user(feature: :cashless, id: 234_567)
+      expect(@redis.sismember('test_user_cashless_blacklist_2', 234_567)).to be true
+      expect(@redis.sismember('test_user_cashless_whitelist', 234_567)).to be false
 
+      @feature_flags.activate_user(feature: :cashless, id: 234_567, live: false)
       expect(@redis.sismember('test_user_cashless_blacklist_2', 234_567)).to be false
       expect(@redis.sismember('test_user_cashless_whitelist', 234_567)).to be true
     end
 
-    it 'removes the user from the blacklist if the feature is live for the city' do
+    it 'removes the user from the blacklist and whitelist if setting the feature as live for the user' do
       @feature_flags.deactivate_user(feature: :cashless, id: 345_678)
       expect(@redis.sismember('test_user_cashless_blacklist_3', 345_678)).to be true
 
       @feature_flags.activate_user(feature: :cashless, id: 345_678, live: true)
       expect(@redis.sismember('test_user_cashless_blacklist_3', 345_678)).to be false
+
+      @feature_flags.activate_user(feature: :cashless, id: 345_678, live: false)
+      expect(@redis.sismember('test_user_cashless_whitelist', 345_678)).to be true
+
+      @feature_flags.activate_user(feature: :cashless, id: 345_678, live: true)
+      expect(@redis.sismember('test_user_cashless_whitelist', 345_678)).to be false
     end
   end
 


### PR DESCRIPTION
Do not take in `city_id` in `activate_user` and `deactivate_user`. But take in a boolean `live` to indicate whether to set the beta flag or live flag. 

Add a `user_state` method, similar to the `city_state` method, returns either `live`, `beta`, or `inactive` as the state of a feature of a user.

Renamed `user_active?` to `user_active_in_city?`
